### PR TITLE
added support for token generation and meta-information

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ and [nodemailer](https://www.npmjs.com/package/nodemailer), inspired by ActionMa
 
 1. create a templates directory with the following naming convention:
   * `foo.text.hbs`, for text email templates.
+  * `foo.meta.hbs`, meta information in JSON format, e.g., `subject`.
   * `foo.html.hbs`, for html email templates.
 
 2. instantiate `MustacheMailer` with:
@@ -32,9 +33,46 @@ var mm = new MustacheMailer({
     to the mustache templates.
 
 ```js
-var msg = mm.message('confirmation').sendMail({
-  to: 'bencoe@gmail.com',
-  name: 'Ben',
-  id: 'adfasdfadsfasdf'
+var msg = mm.message('confirmation', function(err, msg) {
+  msg.sendMail({
+    to: 'bencoe@gmail.com',
+    name: 'Ben',
+    id: 'adfasdfadsfasdf'
+  });
+}
+```
+
+# `tokenFacilitator` Plugin
+
+It often arises that you'd like to toss a token inside an email, e.g.,
+click this confirmation link to change your password.
+
+For generating these tokens, MustacheMailer allows you to install a
+`tokenFacilitator` plugin:
+
+## When instantiating MustacheMailer:
+
+```js
+var mm = new MustacheMailer({
+  transport: mock,
+  templateDir: path.resolve(__dirname, './fixtures'),
+  // a fake token facilitator.
+  tokenFacilitator: {
+    generate: function(data, cb) {
+      setTimeout(function() {
+        data.email.should.eql('zeke@example.com');
+        data.name.should.eql('Zeke');
+        return cb(null, parseInt(Math.random() * 256));
+      }, 20);
+    }
+  }
 });
 ```
+
+# In the template
+
+```mustache
+http://example.com/{{{tokenHelper name=name email=email}}}
+```
+
+* the arguments will be stored as `key`, `value` pairs in data.

--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 var _ = require('lodash'),
   fs = require('fs'),
   Handlebars = require('handlebars'),
+  handlebarsAsync = require('handlebars-async'),
   nodemailer = require('nodemailer'),
   path = require('path'),
   Promise = require('bluebird');
+
+handlebarsAsync(Handlebars);
 
 // the message objects returned by
 // .message()
@@ -16,18 +19,44 @@ Message.prototype.sendMail = function(data, cb) {
   var _this = this,
     content = {};
 
-  return new Promise(function(resolve, reject) {
-    if (_this.templates.html) content.html = _this.templates.html(data);
-    if (_this.templates.text) content.text = _this.templates.text(data);
+  this._expandTemplate(data, _this.templates.html)
+    .then(function(rendered) {
+      if (rendered) content.html = rendered;
+      return _this._expandTemplate(data, _this.templates.text)
+    })
+    .then(function(rendered) {
+      if (rendered) content.text = rendered;
+      return _this._expandTemplate(data, _this.templates.meta)
+    })
+    .then(function(meta) {
+      if (meta) return JSON.parse(meta);
+      else return {};
+    })
+    .then(function(meta) {
+      return new Promise(function(resolve, reject) {
+        _this.transporter.sendMail(_.extend({}, content, meta, data), function(err, info) {
+          if (err) reject(err);
+          else resolve(info);
+        });
+      });
+    })
+    .nodeify(cb);
+};
 
-    _this.transporter.sendMail(_.extend({}, content, data), function(err, info) {
+Message.prototype._expandTemplate = function(data, template) {
+  if (!template) return Promise.cast(null);
+
+  return new Promise(function(resolve, reject) {
+    template(data, function(err, content) {
       if (err) reject(err);
-      else resolve(info);
+      else resolve(content);
     });
-  }).nodeify(cb);
+  });
 };
 
 function MustacheMailer(opts) {
+  var _this = this;
+
   _.extend(this, {
     nodemailer: {}, // node-mailer initialization options.
     transport: null, // the transport method, e.g., SES.
@@ -36,12 +65,25 @@ function MustacheMailer(opts) {
   }, opts);
 
   this.transporter = nodemailer.createTransport(this.transport);
+
+  // if we provide a helper for generating tokens, e.g.,
+  // email signup tokens, register the async helper.
+  if (this.tokenFacilitator) {
+    Handlebars.registerHelper('tokenHelper', function(data) {
+      var done = this.async();
+      _this.tokenFacilitator.generate(data.hash, function(err, token) {
+        if (err) return done(err);
+        else return done(null, token);
+      });
+    });
+  }
 }
 
 MustacheMailer.prototype.message = function(name, cb) {
   var _this = this,
     templates = {},
     htmlPath,
+    metaPath,
     textPath;
 
   if (_this.cache[name]) {
@@ -52,6 +94,7 @@ MustacheMailer.prototype.message = function(name, cb) {
       .then(function(files) {
         htmlPath = _this._resolveTemplateFile(name + '.html.hbs', files);
         textPath = _this._resolveTemplateFile(name + '.text.hbs', files);
+        metaPath = _this._resolveTemplateFile(name + '.meta.hbs', files);
 
         if (textPath) return _this._loadTemplate(textPath);
       })
@@ -61,6 +104,10 @@ MustacheMailer.prototype.message = function(name, cb) {
       })
       .then(function(htmlTemplate) {
         if (htmlTemplate) templates.html = htmlTemplate;
+        if (metaPath) return _this._loadTemplate(metaPath);
+      })
+      .then(function(metaTemplate) {
+        if (metaTemplate) templates.meta = metaTemplate;
       })
       .then(function() {
         var message = new Message(_this.transporter, templates);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "bluebird": "^2.9.9",
     "handlebars": "^3.0.0",
+    "handlebars-async": "0.0.3",
     "lodash": "^3.2.0",
     "nodemailer": "^1.3.0",
     "yargs": "^3.0.4"

--- a/test/fixtures/bar.meta.hbs
+++ b/test/fixtures/bar.meta.hbs
@@ -1,0 +1,4 @@
+{
+  "awesomeName": "Awesome {{name}}",
+  "subject": "my awesome subject"
+}

--- a/test/fixtures/bar.text.hbs
+++ b/test/fixtures/bar.text.hbs
@@ -1,3 +1,5 @@
 Hello {{fname}} glad to meet you.
 
+http://example.com/{{{tokenHelper name=name email=email}}}
+
 -- Ben.


### PR DESCRIPTION
- when instantiating `mustache-mailer`, you can now provide a `tokenFacilitator`, providing this will expose the method `tokenHelper` in your templates. This lets us pull token generation logic into the template, and out of our apps.
- I've also added the concept of a `meta.hbs` template, this allows you to define fields such as, `headers`, `subject`, `to`, inside templates rather than within the application.
