### PR TITLE
Let truthy meta values take precedence over data values

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,13 @@ Message.prototype.sendMail = function(data, cb) {
     })
     .then(function(meta) {
       return new Promise(function(resolve, reject) {
-        _this.transporter.sendMail(_.extend({}, content, meta, data), function(err, info) {
+        // first copy content and override with data
+        var mail = _.extend({}, content, data);
+        // then override with meta if it has a truthy value
+        _.extend(mail, meta, function (mailValue, metaValue) {
+          return metaValue || mailValue;
+        });
+        _this.transporter.sendMail(mail, function(err, info) {
           if (err) reject(err);
           else resolve(info);
         });

--- a/test/fixtures/bar.meta.hbs
+++ b/test/fixtures/bar.meta.hbs
@@ -1,4 +1,6 @@
 {
   "awesomeName": "Awesome {{name}}",
-  "subject": "my awesome subject"
+  "subject": "my awesome subject",
+  "from": "\"Me, Inc.\" <{{from}}>",
+  "to": "{{email}}"
 }

--- a/test/mustache-mailer-test.js
+++ b/test/mustache-mailer-test.js
@@ -60,11 +60,14 @@ describe('MustacheMailer', function() {
         .then(function(msg) {
           msg.sendMail({
             to: 'zeke@example.com',
-            name: 'Zeke'
+            name: 'Zeke',
+            from: 'me@me.co'
           }, function(err) {
             mock.sentMail.length.should.equal(1);
             mock.sentMail[0].data.subject.should.eql('my awesome subject');
             mock.sentMail[0].data.awesomeName.should.eql('Awesome Zeke');
+            mock.sentMail[0].data.to.should.eql('zeke@example.com');
+            mock.sentMail[0].data.from.should.eql('"Me, Inc." <me@me.co>');
             return done();
           });
         });


### PR DESCRIPTION
To support same-name expansions like `"from": "\"npm, Inc.\" <{{from}}>"` in a meta template.

This solves the problem described in npm/email-templates#18.

Real-world scenarios from npm/newww were added to the meta expansion test.

Only use values from meta if they are truthy so we don't break current usage like the following (taken from [here](https://github.com/npm/email-templates/blob/v1.9.2/contact-support.meta.hbs#L3) and [here](https://github.com/npm/newww/blob/v4.0.1/facets/company/show-send-contact.js#L26-L30)).

x.meta.hbs:

``` json
{
  "to": "{{email}}"
}
```

send-x.js:

``` js
// data defines "to" but not "email"
var data = {
  to: 'you@you.co'
};
var mm = new MustacheMailer({
  //...
});
mm.message('x').then(function (msg) {
  msg.sendMail(data);
});
```

Since the meta template will be expanded to `"to": ""`, this should ignore the meta value and use the data value instead.
