### PR TITLE
Bump Node versions for CI to match newww

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
-  - "iojs"
+  - "4"
+  - "5"
 after_script: "NODE_ENV=test YOURPACKAGE_COVERAGE=1 ./node_modules/.bin/mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js"


### PR DESCRIPTION
Specifically, drop Node 0.10, 0.11, and iojs for Node 4 and 5
